### PR TITLE
Slider menu CSS

### DIFF
--- a/core/client/app/styles/layouts/main.css
+++ b/core/client/app/styles/layouts/main.css
@@ -15,29 +15,83 @@
     display: flex;
 }
 
-.gh-nav {
-    flex: 0 0 220px;
-    display: flex;
-    flex-direction: column;
-    border-right: #e1e1e1 1px solid;
-    background: #f6f6f6;
-}
-
 .gh-main {
     position: relative;
     flex-grow: 1;
     display: flex;
+    margin-left: 15px;
+}
+
+.open-nav .gh-main {
+    margin-left: 0;
 }
 
 
 /* Global Nav
 /* ---------------------------------------------------------- */
 
+.gh-nav {
+    position: absolute;
+    top: 0;
+    left: -220px;
+    z-index: 10;
+    display: block;
+    width: 235px;
+    height: 100%;
+    border-right: #e1e1e1 1px solid;
+    background: #f6f6f6;
+    transition: transform 0.2s;
+    transform: translateX(0);
+}
+
+.gh-nav:hover {
+    transform: translateX(220px);
+}
+
+.open-nav .gh-nav {
+    position: static;
+    flex: 0 0 235px;
+    display: flex;
+    flex-direction: column;
+    width: auto;
+    height: auto;
+    transform: translateX(0);
+}
+
+.gh-nav-toggle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 5;
+    width: 15px;
+    height: 100%;
+    text-align: center;
+    cursor: pointer;
+}
+
+.gh-nav-toggle:hover {
+    background-color: rgb(224, 238, 250);
+}
+
+.gh-nav-toggle:after {
+    content: ">";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    font-size: 14px;
+    opacity: 0.25;
+    transform: translateX(-50%) translateY(-50%);
+}
+
+.open-nav .gh-nav-toggle:after {
+    content: "<";
+}
+
 .gh-nav-menu {
     flex-shrink: 0;
     display: flex;
     align-items: center;
-    padding: 15px;
+    padding: 15px 30px 15px 15px;
 }
 
 .gh-nav-menu i {
@@ -93,7 +147,7 @@
 
 .gh-nav-search {
     position: relative;
-    margin: 0 15px 10px;
+    margin: 0 30px 10px;
 }
 
 .gh-nav-search-input {
@@ -127,7 +181,7 @@
 
 .gh-nav-list {
     margin: 0;
-    padding: 0 15px 0 0;
+    padding: 0 30px 0 0;
     list-style: none;
     font-size: 1.3rem;
     line-height: 1.5em;
@@ -174,9 +228,13 @@
 }
 
 .gh-nav-footer {
+    position: absolute;
+    bottom: 0;
     flex-shrink: 0;
     display: flex;
     align-items: center;
+    padding-right: 15px;
+    width: 100%;
     height: 40px;
     border-top: #e1e1e1 1px solid;
 }

--- a/core/client/app/templates/-nav-menu.hbs
+++ b/core/client/app/templates/-nav-menu.hbs
@@ -60,4 +60,5 @@
             {{/gh-dropdown}}
         </div>{{! .help-menu }}
     </footer>
+    <section class="gh-nav-toggle"></section>
 </nav>

--- a/core/client/app/templates/application.hbs
+++ b/core/client/app/templates/application.hbs
@@ -14,7 +14,7 @@
     </aside>
     -->
 
-    <div class="gh-viewport-container">
+    <div class="gh-viewport-container open-nav">
 
         {{#unless signedOut}}
             {{partial "nav-menu"}}

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "bower": "~1.3.10",
-    "csscomb": "^3.0.4",
+    "csscomb": "3.0.4",
     "grunt": "~0.4.5",
     "grunt-bg-shell": "^2.3.1",
     "grunt-cli": "~0.1.13",


### PR DESCRIPTION
This adds some sliding functionality to the sidebar:

![ghost-nav](https://cloud.githubusercontent.com/assets/657707/7714598/7a6330e0-fe45-11e4-950d-fc315ab01792.gif)

**Note: By default, you won't see any slide. This is purely a CSS change, so you can't toggle the menu open/closed yet. Remove the `open-nav` class to get the closed state**