### PR TITLE
Add mobile menu toggle button and action

### DIFF
--- a/core/client/app/components/gh-view-title.js
+++ b/core/client/app/components/gh-view-title.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+    actions: {
+        toggleMobileMenu () {
+            this.sendAction('mobileMenuClick');
+        }
+    }
+});

--- a/core/client/app/controllers/application.js
+++ b/core/client/app/controllers/application.js
@@ -5,7 +5,7 @@ var ApplicationController = Ember.Controller.extend({
     // jscs: enable
 
     topNotificationCount: 0,
-    showGlobalMobileNav: false,
+    showMobileMenu: false,
     showSettingsMenu: false,
 
     userImage: Ember.computed('session.user.image', function () {

--- a/core/client/app/controllers/application.js
+++ b/core/client/app/controllers/application.js
@@ -25,7 +25,13 @@ var ApplicationController = Ember.Controller.extend({
     actions: {
         topNotificationChange: function (count) {
             this.set('topNotificationCount', count);
-        }
+        },
+        resetView: function () {
+            this.setProperties({
+                showSettingsMenu: false,
+                showMobileMenu: false
+            });
+        },
     }
 });
 

--- a/core/client/app/routes/application.js
+++ b/core/client/app/routes/application.js
@@ -35,14 +35,6 @@ ApplicationRoute = Ember.Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
             this.set('controller.showSettingsMenu', true);
         },
 
-        closeSettingsMenu: function () {
-            this.set('controller.showSettingsMenu', false);
-        },
-
-        toggleSettingsMenu: function () {
-            this.toggleProperty('controller.showSettingsMenu');
-        },
-
         closePopups: function () {
             this.get('dropdown').closeDropdowns();
             this.get('notifications').closeAll();

--- a/core/client/app/routes/application.js
+++ b/core/client/app/routes/application.js
@@ -27,8 +27,8 @@ ApplicationRoute = Ember.Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
     },
 
     actions: {
-        toggleGlobalMobileNav: function () {
-            this.toggleProperty('controller.showGlobalMobileNav');
+        toggleMobileMenu () {
+            this.controller.toggleProperty('showMobileMenu');
         },
 
         openSettingsMenu: function () {

--- a/core/client/app/styles/components/notifications.css
+++ b/core/client/app/styles/components/notifications.css
@@ -105,6 +105,7 @@
 
 /* Base alert style */
 .gh-alert {
+    z-index: 1000;
     flex-grow: 1;
     display: flex;
     justify-content: space-between;

--- a/core/client/app/styles/components/settings-menu.css
+++ b/core/client/app/styles/components/settings-menu.css
@@ -19,7 +19,7 @@
     transform: translate3d(350px, 0px, 0px);
 }
 
-body.settings-menu-expanded .settings-menu-container {
+.settings-menu-expanded .settings-menu-container {
     transform: translate3d(0, 0px, 0px);
 }
 
@@ -153,14 +153,20 @@ body.settings-menu-expanded .settings-menu-container {
 /* Background
 /* ---------------------------------------------------------- */
 
-body.settings-menu-expanded .content-cover {
+.settings-menu-expanded .eater-of-clicks-devourer-of-worlds-mother-of-dragons,
+.mobile-menu-expanded .eater-of-clicks-devourer-of-worlds-mother-of-dragons {
     position: absolute;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 600;
+    z-index: 1200;
     transition: transform 0.4s cubic-bezier(0.1, 0.7, 0.1, 1);
-    transform: translate3d(-350px, 0px, 0px);
     /* Not off the screen, to give a parallax effect */
+}
+.settings-menu-expanded .eater-of-clicks-devourer-of-worlds-mother-of-dragons {
+    transform: translate3d(-350px, 0px, 0px);
+}
+.mobile-menu-expanded .eater-of-clicks-devourer-of-worlds-mother-of-dragons {
+    transform: translate3d(235px, 0px, 0px);
 }

--- a/core/client/app/styles/layouts/main.css
+++ b/core/client/app/styles/layouts/main.css
@@ -245,7 +245,7 @@
     }
 
     /* Bring it back on toggle */
-    .gh-main.open {
+    .mobile-menu-expanded .gh-main {
         transition: transform 0.10s;
         transform: translate3d(235px,0,0);
     }
@@ -255,7 +255,7 @@
     .gh-nav {
         width: 75vw;
     }
-    .gh-main.open {
+    .mobile-menu-expanded .gh-main {
         transform: translate3d(75vw,0,0);
     }
 }

--- a/core/client/app/templates/-publish-bar.hbs
+++ b/core/client/app/templates/-publish-bar.hbs
@@ -3,7 +3,7 @@
         {{render 'post-tags-input'}}
 
         <div class="publish-bar-actions">
-            <button type="button" class="post-settings" {{action "toggleSettingsMenu"}}>
+            <button type="button" class="post-settings" {{action "openSettingsMenu"}}>
                 <i class="icon-settings"></i>
             </button>
             {{view "editor-save-button" id="entry-actions" classNameBindings="model.isNew:unsaved"}}

--- a/core/client/app/templates/application.hbs
+++ b/core/client/app/templates/application.hbs
@@ -8,7 +8,7 @@
         {{partial "nav-menu"}}
     {{/unless}}
 
-    <main id="gh-main" class="gh-main" role="main" data-notification-count={{topNotificationCount}}>
+    <main id="gh-main" class="gh-main {{if showMobileMenu 'open'}}" role="main" data-notification-count={{topNotificationCount}}>
         {{outlet}}
     </main>
 

--- a/core/client/app/templates/application.hbs
+++ b/core/client/app/templates/application.hbs
@@ -2,19 +2,20 @@
 
 {{gh-alerts notify="topNotificationChange"}}
 
-<div class="gh-viewport">
+<div class="gh-viewport {{if showSettingsMenu 'settings-menu-expanded'}} {{if showMobileMenu 'mobile-menu-expanded'}}">
 
     {{#unless signedOut}}
         {{partial "nav-menu"}}
     {{/unless}}
 
-    <main id="gh-main" class="gh-main {{if showMobileMenu 'open'}}" role="main" data-notification-count={{topNotificationCount}}>
+    <main id="gh-main" class="gh-main" role="main" data-notification-count={{topNotificationCount}}>
         {{outlet}}
     </main>
 
     {{gh-notifications}}
 
     {{outlet "modal"}}
+    <div class="eater-of-clicks-devourer-of-worlds-mother-of-dragons" {{action "resetView"}}></div>
     {{outlet "settings-menu"}}
 
 </div>{{!gh-viewport}}

--- a/core/client/app/templates/components/gh-view-title.hbs
+++ b/core/client/app/templates/components/gh-view-title.hbs
@@ -1,0 +1,1 @@
+<h2 class="view-title"><button {{action "toggleMobileMenu"}} class="gh-mobilemenu-button" role="presentation"><i class="icon-gh"><span class="sr-only">Menu</span></i></button> {{yield}}</h2>

--- a/core/client/app/templates/post-settings-menu.hbs
+++ b/core/client/app/templates/post-settings-menu.hbs
@@ -1,4 +1,3 @@
-<div class="content-cover" {{action "closeSettingsMenu"}}></div>
 {{#gh-tabs-manager selected="showSubview" id="entry-controls" class="settings-menu-container"}}
 <div id="entry-controls">
     <div class="{{if isViewingSubview 'settings-menu-pane-out-left' 'settings-menu-pane-in'}} settings-menu settings-menu-pane">

--- a/core/client/app/templates/settings/apps.hbs
+++ b/core/client/app/templates/settings/apps.hbs
@@ -1,5 +1,5 @@
 <header class="view-header">
-    <h2 class="view-title">Apps</h2>
+    {{#gh-view-title mobileMenuClick="toggleMobileMenu"}}Apps{{/gh-view-title}}
 </header>
 
 <section class="view-content settings-apps">

--- a/core/client/app/templates/settings/code-injection.hbs
+++ b/core/client/app/templates/settings/code-injection.hbs
@@ -1,5 +1,5 @@
 <header class="view-header">
-    <h2 class="view-title">Code Injection</h2>
+    {{#gh-view-title mobileMenuClick="toggleMobileMenu"}}Code Injection{{/gh-view-title}}
     <section class="view-actions">
         <button type="button" class="btn btn-blue" {{action "save"}}>Save</button>
     </section>

--- a/core/client/app/templates/settings/general.hbs
+++ b/core/client/app/templates/settings/general.hbs
@@ -1,5 +1,5 @@
 <header class="view-header">
-    <h2 class="view-title"><button class="gh-mobilemenu-button" role="presentation"><i class="icon-gh"><span class="sr-only">Menu</span></i></button> General</h2>
+    {{#gh-view-title mobileMenuClick="toggleMobileMenu"}}General{{/gh-view-title}}
     <section class="view-actions">
         <button type="button" class="btn btn-blue" {{action "save"}}>Save</button>
     </section>

--- a/core/client/app/templates/settings/labs.hbs
+++ b/core/client/app/templates/settings/labs.hbs
@@ -1,5 +1,5 @@
 <header class="view-header">
-    <h2 class="view-title">Labs</h2>
+    {{#gh-view-title mobileMenuClick="toggleMobileMenu"}}Labs{{/gh-view-title}}
 </header>
 
 

--- a/core/client/app/templates/settings/navigation.hbs
+++ b/core/client/app/templates/settings/navigation.hbs
@@ -1,5 +1,5 @@
 <header class="view-header">
-    <h2 class="view-title">Navigation</h2>
+    {{#gh-view-title mobileMenuClick="toggleMobileMenu"}}Navigation{{/gh-view-title}}
     <section class="view-actions">
         <button type="button" class="btn btn-blue" {{action "save"}}>Save</button>
     </section>

--- a/core/client/app/templates/settings/tags.hbs
+++ b/core/client/app/templates/settings/tags.hbs
@@ -1,5 +1,5 @@
 <header class="view-header">
-    <h2 class="view-title">Tags</h2>
+    {{#gh-view-title mobileMenuClick="toggleMobileMenu"}}Tags{{/gh-view-title}}
     <section class="view-actions">
         <button type="button" class="btn btn-green" {{action "newTag"}}>New Tag</button>
     </section>

--- a/core/client/app/templates/settings/tags/settings-menu.hbs
+++ b/core/client/app/templates/settings/tags/settings-menu.hbs
@@ -1,4 +1,3 @@
-<div class="content-cover" {{action "closeSettingsMenu"}}></div>
 {{#gh-tabs-manager selected="showSubview" class="settings-menu-container"}}
     <div class="{{if isViewingSubview 'settings-menu-pane-out-left' 'settings-menu-pane-in'}} settings-menu settings-menu-pane">
         <div class="settings-menu-header">

--- a/core/client/app/templates/settings/users/index.hbs
+++ b/core/client/app/templates/settings/users/index.hbs
@@ -1,5 +1,5 @@
     <header class="view-header">
-        <h1 class="view-title">Team</h1>
+        {{#gh-view-title mobileMenuClick="toggleMobileMenu"}}Team{{/gh-view-title}}
         <section class="view-actions">
             <button class="btn btn-green" {{action "openModal" "invite-new-user"}} >Invite People</button>
         </section>

--- a/core/client/app/templates/settings/users/user.hbs
+++ b/core/client/app/templates/settings/users/user.hbs
@@ -1,5 +1,7 @@
 <header class="view-header">
-    <h2 class="view-title">{{#link-to "settings.users"}}Team{{/link-to}} <i class="icon-arrow-right"></i> {{user.name}}</h2>
+    {{#gh-view-title mobileMenuClick="toggleMobileMenu"}}
+        {{#link-to "settings.users"}}Team{{/link-to}} <i class="icon-arrow-right"></i> {{user.name}}
+    {{/gh-view-title}}
     <section class="view-actions">
         {{#if view.userActionsAreVisible}}
             <span class="dropdown">

--- a/core/client/app/views/application.js
+++ b/core/client/app/views/application.js
@@ -16,10 +16,6 @@ var ApplicationView = Ember.View.extend({
             });
         });
 
-        $('.gh-mobilemenu-button').on('click tap', function () {
-            $('.gh-main').toggleClass('open');
-        });
-
         // #### Close the nav if mobile and clicking outside of the nav or not the burger toggle
         $('.js-nav-cover').on('click tap', function () {
             Ember.run(function () {

--- a/core/client/app/views/application.js
+++ b/core/client/app/views/application.js
@@ -5,29 +5,6 @@ var ApplicationView = Ember.View.extend({
     classNames: 'gh-app',
 
     didInsertElement: function () {
-        // #### Navigating within the sidebar closes it.
-        var self = this;
-
-        $('body').on('click tap', '.js-nav-item', function () {
-            Ember.run(function () {
-                if (mobileQuery.matches) {
-                    self.set('controller.showGlobalMobileNav', false);
-                }
-            });
-        });
-
-        // #### Close the nav if mobile and clicking outside of the nav or not the burger toggle
-        $('.js-nav-cover').on('click tap', function () {
-            Ember.run(function () {
-                var isOpen = self.get('controller.showGlobalMobileNav');
-
-                if (isOpen) {
-                    self.set('controller.showGlobalMobileNav', false);
-                }
-            });
-        });
-
-        // TODO: ABOVE - All of this can be removed
         // TODO: BELOW - John wrote this, reimplement in a not-shit way
 
         // #### Toggle nav between fixed and auto
@@ -44,26 +21,7 @@ var ApplicationView = Ember.View.extend({
         $('.gh-main').mouseenter(function () {
             $('.gh-nav').removeClass('open');
         });
-
-        mobileQuery.addListener(this.get('closeGlobalMobileNavOnDesktop'));
-    },
-
-    showGlobalMobileNavObserver: function () {
-        if (this.get('controller.showGlobalMobileNav')) {
-            $('body').addClass('global-nav-expanded');
-        } else {
-            $('body').removeClass('global-nav-expanded');
-        }
-    }.observes('controller.showGlobalMobileNav'),
-
-    willDestroyElement: function () {
-        mobileQuery.removeListener(this.get('closeGlobalMobileNavOnDesktop'));
-        mobileQuery.removeListener(this.get('swapUserMenuDropdownTriangleClasses'));
-    },
-
-    toggleSettingsMenuBodyClass: function () {
-        $('body').toggleClass('settings-menu-expanded', this.get('controller.showSettingsMenu'));
-    }.observes('controller.showSettingsMenu')
+    }
 });
 
 export default ApplicationView;

--- a/core/client/app/views/mobile/content-view.js
+++ b/core/client/app/views/mobile/content-view.js
@@ -5,7 +5,10 @@ var MobileContentView = Ember.View.extend({
     // Ensure that loading this view brings it into view on mobile
     showContent: function () {
         if (mobileQuery.matches) {
-            this.get('parentView').showContent();
+            var parent = this.get('parentView');
+            if (parent.showContent) {
+                parent.showContent();
+            }
         }
     }.on('didInsertElement')
 });


### PR DESCRIPTION
- Adds gh-view-title component to implement mobile menu button for titles on any page
- ~~@TODO: close the menu with a click anywhere off it (currently can toggle via button)~~
- @TODO: How should menu state transition between desktop/mobile sizes?

regarding the second todo, if the desktop menu is locked open, what should its state be upon transitioning into the mobile view? what if it's closed? what if the user went from mobile open -> desktop -> mobile? (we can know the state of the menu the last time we were in mobile layout, should we pick it back up?)